### PR TITLE
fix: use csv columns names from views (works also for empty results)

### DIFF
--- a/bin/rdf-cube-view.js
+++ b/bin/rdf-cube-view.js
@@ -102,7 +102,7 @@ program
       const customView = new View({ dimensions, filters })
       const observations = await customView.observations()
 
-      console.log(toCsv(observations))
+      console.log(toCsv(customView, observations))
     }
   })
 

--- a/lib/utils-cli.js
+++ b/lib/utils-cli.js
@@ -3,7 +3,8 @@ const namespace = require('@rdfjs/namespace')
 
 const ns = {
   schema: namespace('http://schema.org/'),
-  xsd: namespace('http://www.w3.org/2001/XMLSchema#')
+  xsd: namespace('http://www.w3.org/2001/XMLSchema#'),
+  view: namespace('http://ns.bergnet.org/cube-view/')
 }
 
 function collect (str, all) {
@@ -28,8 +29,8 @@ function cubeFilter ({ cubeName, cubeUrl }) {
   }
 }
 
-function toCsv (observations) {
-  const columns = Object.keys(observations[0])
+function toCsv (view, observations) {
+  const columns = view.dimensions.map(d => d.ptr.out(ns.view.as).value)
 
   return [columns.join(',')].concat(observations.map(observation => {
     return columns.map(column => observation[column]).map(c => c.value).join(',')


### PR DESCRIPTION
The CSV write uses the first observation to generate the column names. This causes an error if there are no observations. This PR changes the behavior to use directly `view:as` from the dimension, which is always available.