### PR TITLE
feat: added cube filters

### DIFF
--- a/examples/lindas-cube-search.js
+++ b/examples/lindas-cube-search.js
@@ -1,0 +1,30 @@
+const { Cube, Source } = require('..')
+const namespace = require('@rdfjs/namespace')
+
+const ns = {
+  adminTerm: namespace('https://ld.admin.ch/definedTerm/'),
+  schema: namespace('http://schema.org/')
+}
+
+async function main () {
+  const source = new Source({
+    endpointUrl: 'https://test.lindas.admin.ch/query'
+  })
+
+  // the source can be used to search for cubes and allows server side filtering
+  const cubes = await source.cubes({
+    filters: [
+      Cube.filter.noValidThrough(),
+      Cube.filter.status(ns.adminTerm('creativeWorkStatus/published'))
+    ]
+  })
+
+  for (const cube of cubes) {
+    const iri = cube.term.value
+    const label = cube.out(ns.schema.name, { language: ['en', 'de', '*'] })
+
+    console.log(`${iri}: ${label}`)
+  }
+}
+
+main()

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+const Cube = require('./lib/Cube')
 const CubeSource = require('./lib/CubeSource')
 const Dimension = require('./lib/Dimension')
 const Filter = require('./')
@@ -7,6 +8,7 @@ const Source = require('./lib/Source')
 const View = require('./lib/View')
 
 module.exports = {
+  Cube,
   CubeSource,
   Dimension,
   Filter,

--- a/lib/Cube.js
+++ b/lib/Cube.js
@@ -1,6 +1,7 @@
 const CubeDimension = require('./CubeDimension')
 const Node = require('./Node')
 const ns = require('./namespaces')
+const queryFilter = require('./query/cubesFilter')
 
 class Cube extends Node {
   constructor ({ parent, term, dataset, graph, source }) {
@@ -62,6 +63,18 @@ class Cube extends Node {
   out (...args) {
     return this.ptr.out(...args)
   }
+}
+
+Cube.filter = { ...queryFilter }
+
+Cube.filter.noValidThrough = () => {
+  return Cube.filter.notExists(ns.schema.validThrough)
+}
+
+Cube.filter.status = values => {
+  values = Array.isArray(values) ? values : [values]
+
+  return Cube.filter.in(ns.schema.creativeWorkStatus, values)
 }
 
 module.exports = Cube

--- a/lib/Source.js
+++ b/lib/Source.js
@@ -1,10 +1,10 @@
 const rdf = require('rdf-ext')
-const sparql = require('rdf-sparql-builder')
 const ParsingClient = require('sparql-http-client/ParsingClient')
 const Cube = require('./Cube')
 const Node = require('./Node')
 const ns = require('./namespaces')
 const { toTerm } = require('./utils')
+const cubesQuery = require('./query/cubes.js')
 
 class Source extends Node {
   constructor ({ parent, term, dataset, graph, endpointUrl, sourceGraph = rdf.defaultGraph(), user, password }) {
@@ -41,15 +41,6 @@ class Source extends Node {
     return this.ptr.out(ns.view.graph).term
   }
 
-  cubesQuery () {
-    const cube = rdf.variable('cube')
-
-    return sparql.select([cube])
-      .from(this.graph)
-      .where([[cube, ns.rdf.type, ns.cube.Cube]])
-      .toString()
-  }
-
   async cube (term) {
     const cube = new Cube({
       parent: this,
@@ -67,8 +58,11 @@ class Source extends Node {
     return cube
   }
 
-  async cubes () {
-    const rows = await this.client.query.select(this.cubesQuery())
+  async cubes ({ filters } = {}) {
+    const rows = await this.client.query.select(cubesQuery({
+      graph: this.graph,
+      filters
+    }))
 
     return Promise.all(rows.map(async row => {
       const cube = new Cube({

--- a/lib/namespaces.js
+++ b/lib/namespaces.js
@@ -3,6 +3,7 @@ const namespace = require('@rdfjs/namespace')
 const ns = {
   cube: namespace('http://ns.bergnet.org/cube/'),
   rdf: namespace('http://www.w3.org/1999/02/22-rdf-syntax-ns#'),
+  schema: namespace('http://schema.org/'),
   sh: namespace('http://www.w3.org/ns/shacl#'),
   view: namespace('http://ns.bergnet.org/cube-view/')
 }

--- a/lib/query/cubes.js
+++ b/lib/query/cubes.js
@@ -1,0 +1,24 @@
+const rdf = require('rdf-ext')
+const sparql = require('rdf-sparql-builder')
+const ns = require('../namespaces.js')
+
+function cubesQuery ({ filters = [], graph = rdf.defaultGraph() } = {}) {
+  const cube = rdf.variable('cube')
+
+  const patterns = [[cube, ns.rdf.type, ns.cube.Cube]]
+
+  for (const [index, filter] of filters.entries()) {
+    const content = filter({ cube, index })
+
+    for (const c of content) {
+      patterns.push(c)
+    }
+  }
+
+  return sparql.select([cube])
+    .from(graph)
+    .where(patterns)
+    .toString()
+}
+
+module.exports = cubesQuery

--- a/lib/query/cubesFilter.js
+++ b/lib/query/cubesFilter.js
@@ -1,0 +1,29 @@
+const rdf = require('rdf-ext')
+const sparql = require('rdf-sparql-builder')
+
+const filter = {}
+
+filter.in = (predicate, values) => {
+  return ({ cube, index }) => {
+    const variable = rdf.variable(`v${index}`)
+
+    return [
+      [cube, predicate, variable],
+      sparql.filter([sparql.in(variable, values)])
+    ]
+  }
+}
+
+filter.notExists = (predicate, value) => {
+  return ({ cube, index }) => {
+    value = value || rdf.variable(`v${index}`)
+
+    return [
+      sparql.filter([
+        `NOT EXISTS { ${rdf.quad(cube, predicate, value).toString()} }`
+      ])
+    ]
+  }
+}
+
+module.exports = filter

--- a/test/Cube.test.js
+++ b/test/Cube.test.js
@@ -1,0 +1,50 @@
+const { strictEqual } = require('assert')
+const { describe, it } = require('mocha')
+const cubesQuery = require('../lib/query/cubes')
+const Cube = require('../lib/Cube')
+const { compareQuery } = require('./support/compareQuery')
+const ns = require('./support/namespaces')
+
+describe('Cube', () => {
+  it('should be a constructor', () => {
+    strictEqual(typeof Cube, 'function')
+  })
+
+  describe('filter', () => {
+    describe('noValidThrough', () => {
+      it('should be a function', () => {
+        strictEqual(typeof Cube.filter.noValidThrough, 'function')
+      })
+
+      it('should create a not exists filter for schema:noValidThrough', async () => {
+        const query = cubesQuery({
+          filters: [Cube.filter.noValidThrough()]
+        })
+
+        await compareQuery({ name: 'CubeFilterNoValidThrough', query })
+      })
+    })
+
+    describe('status', () => {
+      it('should be a function', () => {
+        strictEqual(typeof Cube.filter.status, 'function')
+      })
+
+      it('should create an in filter for the given status value', async () => {
+        const query = cubesQuery({
+          filters: [Cube.filter.status(ns.ex.status)]
+        })
+
+        await compareQuery({ name: 'CubeFilterStatusValue', query })
+      })
+
+      it('should create an in filter for the given status values', async () => {
+        const query = cubesQuery({
+          filters: [Cube.filter.status([ns.ex.status1, ns.ex.status2])]
+        })
+
+        await compareQuery({ name: 'CubeFilterStatusValues', query })
+      })
+    })
+  })
+})

--- a/test/cubesQuery.test.js
+++ b/test/cubesQuery.test.js
@@ -1,0 +1,56 @@
+const { deepStrictEqual, strictEqual } = require('assert')
+const { describe, it } = require('mocha')
+const cubesQuery = require('../lib/query/cubes')
+const { compareQuery } = require('./support/compareQuery')
+const ns = require('./support/namespaces')
+
+describe('query/cubes', () => {
+  it('should be a function', () => {
+    strictEqual(typeof cubesQuery, 'function')
+  })
+
+  it('should create a query that finds all cube:Cube terms', async () => {
+    const query = cubesQuery()
+
+    await compareQuery({ name: 'cubes', query })
+  })
+
+  it('should use the given named graph', async () => {
+    const graph = ns.ex.graph
+
+    const query = cubesQuery({ graph })
+
+    await compareQuery({ name: 'cubesGraph', query })
+  })
+
+  it('should call the filters functions', async () => {
+    const args = []
+
+    const filter = name => {
+      return ({ cube, index }) => {
+        args.push({ name, termType: cube.termType, value: cube.value, index })
+
+        return []
+      }
+    }
+
+    cubesQuery({ filters: [filter('1'), filter('2')] })
+
+    deepStrictEqual(args, [
+      { name: '1', termType: 'Variable', value: 'cube', index: 0 },
+      { name: '2', termType: 'Variable', value: 'cube', index: 1 }
+    ])
+  })
+
+  it('should use the result of the filter functions', async () => {
+    const filter = name => {
+      return ({ index }) => {
+        return [`# ${name} ${index}`]
+      }
+    }
+
+    const query = cubesQuery({ filters: [filter('1'), filter('2')] })
+
+    await compareQuery({ name: 'cubesFilter', query })
+  })
+})

--- a/test/cubesQueryFilter.test.js
+++ b/test/cubesQueryFilter.test.js
@@ -1,0 +1,56 @@
+const { strictEqual } = require('assert')
+const { describe, it } = require('mocha')
+const cubesQuery = require('../lib/query/cubes')
+const cubesFilterQuery = require('../lib/query/cubesFilter')
+const { compareQuery } = require('./support/compareQuery')
+const ns = require('./support/namespaces')
+
+describe('query/cubesFilter', () => {
+  it('should be an object', () => {
+    strictEqual(typeof cubesFilterQuery, 'object')
+  })
+
+  describe('in', () => {
+    it('should be a function', () => {
+      strictEqual(typeof cubesFilterQuery.in, 'function')
+    })
+
+    it('should create a triple pattern an in filter', async () => {
+      const predicate = ns.ex.property
+      const values = [ns.ex.value1, ns.ex.value2]
+
+      const query = cubesQuery({
+        filters: [cubesFilterQuery.in(predicate, values)]
+      })
+
+      await compareQuery({ name: 'cubesFilterIn', query })
+    })
+  })
+
+  describe('notExists', () => {
+    it('should be a function', () => {
+      strictEqual(typeof cubesFilterQuery.notExists, 'function')
+    })
+
+    it('should create not exists filter', async () => {
+      const predicate = ns.ex.property
+      const value = ns.ex.value
+
+      const query = cubesQuery({
+        filters: [cubesFilterQuery.notExists(predicate, value)]
+      })
+
+      await compareQuery({ name: 'cubesFilterNotExists', query })
+    })
+
+    it('should create not exists filter with object variable if not value is given', async () => {
+      const predicate = ns.ex.property
+
+      const query = cubesQuery({
+        filters: [cubesFilterQuery.notExists(predicate)]
+      })
+
+      await compareQuery({ name: 'cubesFilterNotExistsNoValue', query })
+    })
+  })
+})

--- a/test/support/CubeFilterNoValidThrough.query.txt
+++ b/test/support/CubeFilterNoValidThrough.query.txt
@@ -1,0 +1,9 @@
+SELECT ?cube WHERE {
+  ?cube <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://ns.bergnet.org/cube/Cube> .
+
+  FILTER (
+    NOT EXISTS {
+      ?cube <http://schema.org/validThrough> ?v0 .
+    }
+  )
+}

--- a/test/support/CubeFilterStatusValue.query.txt
+++ b/test/support/CubeFilterStatusValue.query.txt
@@ -1,0 +1,8 @@
+SELECT ?cube WHERE {
+  ?cube <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://ns.bergnet.org/cube/Cube> .
+  ?cube <http://schema.org/creativeWorkStatus> ?v0 .
+
+  FILTER (
+    (?v0 IN (<http://example.org/status>))
+  )
+}

--- a/test/support/CubeFilterStatusValues.query.txt
+++ b/test/support/CubeFilterStatusValues.query.txt
@@ -1,0 +1,8 @@
+SELECT ?cube WHERE {
+  ?cube <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://ns.bergnet.org/cube/Cube> .
+  ?cube <http://schema.org/creativeWorkStatus> ?v0 .
+
+  FILTER (
+    (?v0 IN (<http://example.org/status1>, <http://example.org/status2>))
+  )
+}

--- a/test/support/compareQuery.js
+++ b/test/support/compareQuery.js
@@ -1,0 +1,10 @@
+const { strictEqual } = require('assert')
+const { cleanQuery, queryFromTxt } = require('./utils')
+
+async function compareQuery ({ name, query }) {
+  strictEqual(cleanQuery(query), await queryFromTxt(name))
+}
+
+module.exports = {
+  compareQuery
+}

--- a/test/support/compareViewQuery.js
+++ b/test/support/compareViewQuery.js
@@ -1,16 +1,9 @@
 const { strictEqual } = require('assert')
-const { readFile } = require('fs').promises
 const clownface = require('clownface')
 const rdf = require('rdf-ext')
 const fromFile = require('rdf-utils-fs/fromFile')
 const ViewQuery = require('../../lib/query/ViewQuery')
-
-function cleanQuery (query) {
-  return query
-    .replace(/\n/g, ' ')
-    .replace(/ +/g, ' ')
-    .trim()
-}
+const { cleanQuery, queryFromTxt } = require('./utils')
 
 async function viewQueryFromTtl (name) {
   const filename = `test/support/${name}.ttl`
@@ -27,15 +20,8 @@ async function viewQueryFromTtl (name) {
   return cleanQuery(viewQuery.query.toString())
 }
 
-async function viewQueryFromTxt (name) {
-  const filename = `test/support/${name}.query.txt`
-  const content = await readFile(filename)
-
-  return cleanQuery(content.toString())
-}
-
 async function compareViewQuery ({ name }) {
-  strictEqual(await viewQueryFromTtl(name), await viewQueryFromTxt(name))
+  strictEqual(await viewQueryFromTtl(name), await queryFromTxt(name))
 }
 
 module.exports = {

--- a/test/support/cubes.query.txt
+++ b/test/support/cubes.query.txt
@@ -1,0 +1,3 @@
+SELECT ?cube WHERE {
+  ?cube <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://ns.bergnet.org/cube/Cube> .
+}

--- a/test/support/cubesFilter.query.txt
+++ b/test/support/cubesFilter.query.txt
@@ -1,0 +1,5 @@
+SELECT ?cube WHERE {
+  ?cube <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://ns.bergnet.org/cube/Cube> .
+  # 1 0
+  # 2 1
+}

--- a/test/support/cubesFilterIn.query.txt
+++ b/test/support/cubesFilterIn.query.txt
@@ -1,0 +1,8 @@
+SELECT ?cube WHERE {
+  ?cube <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://ns.bergnet.org/cube/Cube> .
+  ?cube <http://example.org/property> ?v0 .
+
+  FILTER (
+    (?v0 IN (<http://example.org/value1>, <http://example.org/value2>))
+  )
+}

--- a/test/support/cubesFilterNotExists.query.txt
+++ b/test/support/cubesFilterNotExists.query.txt
@@ -1,0 +1,9 @@
+SELECT ?cube WHERE {
+  ?cube <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://ns.bergnet.org/cube/Cube> .
+
+  FILTER (
+    NOT EXISTS {
+      ?cube <http://example.org/property> <http://example.org/value> .
+    }
+  )
+}

--- a/test/support/cubesFilterNotExistsNoValue.query.txt
+++ b/test/support/cubesFilterNotExistsNoValue.query.txt
@@ -1,0 +1,9 @@
+SELECT ?cube WHERE {
+  ?cube <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://ns.bergnet.org/cube/Cube> .
+
+  FILTER (
+    NOT EXISTS {
+      ?cube <http://example.org/property> ?v0 .
+    }
+  )
+}

--- a/test/support/cubesGraph.query.txt
+++ b/test/support/cubesGraph.query.txt
@@ -1,0 +1,3 @@
+SELECT ?cube FROM <http://example.org/graph> WHERE {
+  ?cube <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://ns.bergnet.org/cube/Cube> .
+}

--- a/test/support/namespaces.js
+++ b/test/support/namespaces.js
@@ -1,0 +1,7 @@
+const namespace = require('@rdfjs/namespace')
+
+const ns = {
+  ex: namespace('http://example.org/')
+}
+
+module.exports = ns

--- a/test/support/utils.js
+++ b/test/support/utils.js
@@ -1,0 +1,20 @@
+const { readFile } = require('fs').promises
+
+function cleanQuery (query) {
+  return query
+    .replace(/\n/g, ' ')
+    .replace(/ +/g, ' ')
+    .trim()
+}
+
+async function queryFromTxt (name) {
+  const filename = `test/support/${name}.query.txt`
+  const content = await readFile(filename)
+
+  return cleanQuery(content.toString())
+}
+
+module.exports = {
+  cleanQuery,
+  queryFromTxt
+}


### PR DESCRIPTION
This PR adds a `filters` argument to the `Source.cubes()` method to add server side filters. `Cube.filter` contains multiple filters:

- `in(predicate, values)`: Only accept cubes which have the given property with a value in values.
- `notExists(predicate, value)`: Only accepts cubes which don't have the given property and optional with a specific value.
- `noValidThrough()`: Only accepts cubes which don't have a `schema:validThrough` property.
- `status(values)`: Only accepts cubes with a matching `schema:creativeWorkStatus`.