### PR TITLE
feat: added support for version history (cube filter, Cube.in(), improved cube DESCRIBE query)

### DIFF
--- a/examples/lindas-cube-latest.js
+++ b/examples/lindas-cube-latest.js
@@ -1,4 +1,5 @@
 const { Cube, Source } = require('..')
+const rdf = require('rdf-ext')
 const namespace = require('@rdfjs/namespace')
 
 const ns = {
@@ -11,9 +12,10 @@ async function main () {
     endpointUrl: 'https://test.lindas.admin.ch/query'
   })
 
-  // the source can be used to search for cubes and allows server side filtering
+  // the isPartOf filter allows to search only in a specific version history
   const cubes = await source.cubes({
     filters: [
+      Cube.filter.isPartOf(rdf.namedNode('https://environment.ld.admin.ch/foen/bil-p-01')),
       Cube.filter.noValidThrough(),
       Cube.filter.status(ns.adminTerm('creativeWorkStatus/published'))
     ]
@@ -22,9 +24,8 @@ async function main () {
   for (const cube of cubes) {
     const iri = cube.term.value
     const label = cube.out(ns.schema.name, { language: ['en', 'de', '*'] })
-    const versionHistory = cube.in(ns.schema.hasPart).value
 
-    console.log(`${iri}: ${label} (${versionHistory})`)
+    console.log(`${iri}: ${label}`)
   }
 }
 

--- a/lib/Cube.js
+++ b/lib/Cube.js
@@ -1,6 +1,7 @@
 const CubeDimension = require('./CubeDimension')
 const Node = require('./Node')
 const ns = require('./namespaces')
+const cubeQuery = require('./query/cube.js')
 const queryFilter = require('./query/cubesFilter')
 
 class Cube extends Node {
@@ -33,11 +34,10 @@ class Cube extends Node {
   }
 
   cubeQuery () {
-    if (this.source.graph.termType === 'DefaultGraph') {
-      return `${this.queryPrefix}DESCRIBE <${this.ptr.value}>`
-    }
+    const prefix = this.queryPrefix || ''
+    const query = cubeQuery({ cube: this.term, graph: this.source.graph })
 
-    return `${this.queryPrefix}DESCRIBE <${this.ptr.value}> FROM <${this.source.graph.value}>`
+    return [prefix, query.toString()].join('')
   }
 
   shapeQuery () {
@@ -63,9 +63,17 @@ class Cube extends Node {
   out (...args) {
     return this.ptr.out(...args)
   }
+
+  in (...args) {
+    return this.ptr.in(...args)
+  }
 }
 
 Cube.filter = { ...queryFilter }
+
+Cube.filter.isPartOf = container => {
+  return Cube.filter.patternIn(ns.schema.hasPart, container)
+}
 
 Cube.filter.noValidThrough = () => {
   return Cube.filter.notExists(ns.schema.validThrough)

--- a/lib/query/cube.js
+++ b/lib/query/cube.js
@@ -1,0 +1,22 @@
+const rdf = require('rdf-ext')
+const sparql = require('rdf-sparql-builder')
+const ns = require('../namespaces.js')
+
+function cubeQuery ({ cube, graph = rdf.defaultGraph() } = {}) {
+  const subject = rdf.variable('subject')
+
+  const cubePattern = [sparql.bind(subject, `<${cube.value}>`)]
+  const versionHistoryPattern = [[subject, ns.schema.hasPart, cube]]
+
+  const patterns = [sparql.union([
+    cubePattern,
+    versionHistoryPattern
+  ])]
+
+  return sparql.describe([subject])
+    .from(graph)
+    .where(patterns)
+    .toString()
+}
+
+module.exports = cubeQuery

--- a/lib/query/cubesFilter.js
+++ b/lib/query/cubesFilter.js
@@ -26,4 +26,14 @@ filter.notExists = (predicate, value) => {
   }
 }
 
+filter.patternIn = (predicate, subject) => {
+  return ({ cube, index }) => {
+    const variable = rdf.variable(`v${index}`)
+
+    return [
+      [subject || variable, predicate, cube]
+    ]
+  }
+}
+
 module.exports = filter

--- a/test/Cube.test.js
+++ b/test/Cube.test.js
@@ -2,6 +2,7 @@ const { strictEqual } = require('assert')
 const { describe, it } = require('mocha')
 const cubesQuery = require('../lib/query/cubes')
 const Cube = require('../lib/Cube')
+const Source = require('../lib/Source')
 const { compareQuery } = require('./support/compareQuery')
 const ns = require('./support/namespaces')
 
@@ -11,6 +12,21 @@ describe('Cube', () => {
   })
 
   describe('filter', () => {
+    describe('isPartOf', () => {
+      it('should be a function', () => {
+        strictEqual(typeof Cube.filter.isPartOf, 'function')
+      })
+
+      it('should create a patter in filter for schema:hasPart', async () => {
+        const versionHistory = ns.ex.versionHistory
+        const query = cubesQuery({
+          filters: [Cube.filter.isPartOf(versionHistory)]
+        })
+
+        await compareQuery({ name: 'CubeFilterIsPartOf', query })
+      })
+    })
+
     describe('noValidThrough', () => {
       it('should be a function', () => {
         strictEqual(typeof Cube.filter.noValidThrough, 'function')
@@ -45,6 +61,46 @@ describe('Cube', () => {
 
         await compareQuery({ name: 'CubeFilterStatusValues', query })
       })
+    })
+  })
+
+  describe('in', () => {
+    it('should be a method', () => {
+      const source = new Source({ endpointUrl: ns.ex.endpoint })
+      const cube = new Cube({ parent: source })
+
+      strictEqual(typeof cube.in, 'function')
+    })
+
+    it('should use clownface to search for triples pointing to the cube', () => {
+      const source = new Source({ endpointUrl: ns.ex.endpoint })
+      const cube = new Cube({ parent: source })
+
+      cube.ptr
+        .addIn(ns.ex.predicate, ns.ex.up)
+        .addOut(ns.ex.predicate, ns.ex.down)
+
+      strictEqual(ns.ex.up.equals(cube.in(ns.ex.predicate).term), true)
+    })
+  })
+
+  describe('out', () => {
+    it('should be a method', () => {
+      const source = new Source({ endpointUrl: ns.ex.endpoint })
+      const cube = new Cube({ parent: source })
+
+      strictEqual(typeof cube.out, 'function')
+    })
+
+    it('should use clownface to search for triples starting at the cube', () => {
+      const source = new Source({ endpointUrl: ns.ex.endpoint })
+      const cube = new Cube({ parent: source })
+
+      cube.ptr
+        .addIn(ns.ex.predicate, ns.ex.up)
+        .addOut(ns.ex.predicate, ns.ex.down)
+
+      strictEqual(ns.ex.down.equals(cube.out(ns.ex.predicate).term), true)
     })
   })
 })

--- a/test/cubeQuery.test.js
+++ b/test/cubeQuery.test.js
@@ -1,0 +1,26 @@
+const { strictEqual } = require('assert')
+const { describe, it } = require('mocha')
+const cubeQuery = require('../lib/query/cube')
+const { compareQuery } = require('./support/compareQuery')
+const ns = require('./support/namespaces')
+
+describe('query/cube', () => {
+  it('should be a function', () => {
+    strictEqual(typeof cubeQuery, 'function')
+  })
+
+  it('should create a DESCRIBE query for the cube and the version history', async () => {
+    const cube = ns.ex.cube
+    const query = cubeQuery({ cube })
+
+    await compareQuery({ name: 'cube', query })
+  })
+
+  it('should use the given named graph', async () => {
+    const cube = ns.ex.cube
+    const graph = ns.ex.graph
+    const query = cubeQuery({ cube, graph })
+
+    await compareQuery({ name: 'cubeGraph', query })
+  })
+})

--- a/test/cubesQueryFilter.test.js
+++ b/test/cubesQueryFilter.test.js
@@ -53,4 +53,31 @@ describe('query/cubesFilter', () => {
       await compareQuery({ name: 'cubesFilterNotExistsNoValue', query })
     })
   })
+
+  describe('patternIn', () => {
+    it('should be a function', () => {
+      strictEqual(typeof cubesFilterQuery.patternIn, 'function')
+    })
+
+    it('should add a triple pattern with the cube as object and the given predicate', async () => {
+      const predicate = ns.ex.property
+
+      const query = cubesQuery({
+        filters: [cubesFilterQuery.patternIn(predicate)]
+      })
+
+      await compareQuery({ name: 'cubesFilterPatternIn', query })
+    })
+
+    it('should add a triple pattern with the cube as object and the give subject', async () => {
+      const predicate = ns.ex.property
+      const subject = ns.ex.subject
+
+      const query = cubesQuery({
+        filters: [cubesFilterQuery.patternIn(predicate, subject)]
+      })
+
+      await compareQuery({ name: 'cubesFilterPatternInSubject', query })
+    })
+  })
 })

--- a/test/support/CubeFilterIsPartOf.query.txt
+++ b/test/support/CubeFilterIsPartOf.query.txt
@@ -1,0 +1,4 @@
+SELECT ?cube WHERE {
+  ?cube <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://ns.bergnet.org/cube/Cube> .
+  <http://example.org/versionHistory> <http://schema.org/hasPart> ?cube .
+}

--- a/test/support/cube.query.txt
+++ b/test/support/cube.query.txt
@@ -1,0 +1,7 @@
+DESCRIBE ?subject WHERE {
+  {
+    BIND(<http://example.org/cube> AS ?subject)
+  } UNION {
+    ?subject <http://schema.org/hasPart> <http://example.org/cube> .
+  }
+}

--- a/test/support/cubeGraph.query.txt
+++ b/test/support/cubeGraph.query.txt
@@ -1,0 +1,7 @@
+DESCRIBE ?subject FROM <http://example.org/graph> WHERE {
+  {
+    BIND(<http://example.org/cube> AS ?subject)
+  } UNION {
+    ?subject <http://schema.org/hasPart> <http://example.org/cube> .
+  }
+}

--- a/test/support/cubesFilterPatternIn.query.txt
+++ b/test/support/cubesFilterPatternIn.query.txt
@@ -1,0 +1,4 @@
+SELECT ?cube WHERE {
+  ?cube <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://ns.bergnet.org/cube/Cube> .
+  ?v0 <http://example.org/property> ?cube .
+}

--- a/test/support/cubesFilterPatternInSubject.query.txt
+++ b/test/support/cubesFilterPatternInSubject.query.txt
@@ -1,0 +1,4 @@
+SELECT ?cube WHERE {
+  ?cube <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://ns.bergnet.org/cube/Cube> .
+  <http://example.org/subject> <http://example.org/property> ?cube .
+}


### PR DESCRIPTION
This PR:

- extends the `DESCRIBE` query used to get the cube metadata. Now it also checks the inverse of `schema:hasPart` for the version history.
- adds a `Cube.in()` method. It's just forwarding the clownface method to be able to check the version history.
- adds a `Cube.filter.patternIn()` filter. Adds a triple pattern with the cube variable as object.
- adds a `Cube.filter.isPartOf()` filter. It's an inverse filter of `schema:hasPart` to filter based on the version history term.
- examples how to find the version history term and how to use it to find the latest version of a specific cube.