### PR TITLE
fix: do not crash when dimension property has no sh:path

### DIFF
--- a/lib/Cube.js
+++ b/lib/Cube.js
@@ -32,7 +32,10 @@ class Cube extends Node {
     return this.ptr
       .out(ns.cube.observationConstraint)
       .out(ns.sh.property)
-      .filter(property => !this.ignore.has(property.out(ns.sh.path).term))
+      .filter(property => {
+        const path = property.out(ns.sh.path).term
+        return path && !this.ignore.has(path)
+      })
       .map(ptr => new CubeDimension({ term: ptr.term, dataset: this.dataset }))
   }
 


### PR DESCRIPTION
If a property of the metadata shape had no `sh:path` (or multiple of them), `Cube.dimensions` would crash. This PR just ignores malformed dimension properties.