### PR TITLE
feat: added optional property to CubeDimension, ignore cube:Undefined datatype

### DIFF
--- a/lib/CubeDimension.js
+++ b/lib/CubeDimension.js
@@ -11,8 +11,18 @@ class CubeDimension {
     return this.ptr.out(ns.sh.path).term
   }
 
+  get optional () {
+    const optionalDatatype = this.ptr.out(ns.sh.or).out(ns.sh.datatype).filter(d => ns.cube.Undefined.equals(d.term)).term
+    const optionalValue = this.in.some(v => ns.cube.Undefined.equals(v))
+
+    return Boolean(optionalDatatype || optionalValue)
+  }
+
   get datatype () {
-    return this.ptr.out(ns.sh.datatype).term
+    const nonOptional = this.ptr.out(ns.sh.datatype).term
+    const withOptional = this.ptr.out(ns.sh.or).out(ns.sh.datatype).filter(d => !ns.cube.Undefined.equals(d.term)).term
+
+    return nonOptional || withOptional
   }
 
   get minExclusive () {

--- a/test/Cube.test.js
+++ b/test/Cube.test.js
@@ -22,9 +22,9 @@ describe('Cube', () => {
     it('should contain all dimensions of the cube without rdf:type', () => {
       const cube = buildCube({
         dimensions: [{
-          term: ns.ex.propertyA
+          path: ns.ex.propertyA
         }, {
-          term: ns.ex.propertyB
+          path: ns.ex.propertyB
         }]
       })
 

--- a/test/CubeDimension.test.js
+++ b/test/CubeDimension.test.js
@@ -1,0 +1,69 @@
+const { strictEqual } = require('assert')
+const { describe, it } = require('mocha')
+const rdf = require('rdf-ext')
+const CubeDimension = require('../lib/CubeDimension')
+const buildCubeDimension = require('./support/buildCubeDimension')
+const ns = require('./support/namespaces')
+
+describe('CubeDimension', () => {
+  it('should be a constructor', () => {
+    strictEqual(typeof CubeDimension, 'function')
+  })
+
+  it('should create a ptr for the given term, dataset, graph', () => {
+    const term = ns.ex.test
+    const dataset = rdf.dataset()
+    const graph = ns.ex.graph
+    const dimension = new CubeDimension({ term, dataset, graph })
+
+    strictEqual(dimension.ptr.term.equals(term), true)
+    strictEqual(dimension.ptr.dataset, dataset)
+    strictEqual(dimension.ptr._context[0].graph.equals(graph), true)
+  })
+
+  describe('.datatype', () => {
+    it('should be undefined if no datatype is defined', () => {
+      const dimension = buildCubeDimension({ path: ns.ex.property })
+
+      strictEqual(typeof dimension.datatype, 'undefined')
+    })
+
+    it('should be the term defined sh:datatype', () => {
+      const dimension = buildCubeDimension({ path: ns.ex.property, datatype: ns.ex.datatype })
+
+      strictEqual(ns.ex.datatype.equals(dimension.datatype), true)
+    })
+
+    it('should be the term defined in sh:datatype that is not cube:Undefined', () => {
+      const dimension = buildCubeDimension({ path: ns.ex.property, datatype: ns.ex.datatype, optional: true })
+
+      strictEqual(ns.ex.datatype.equals(dimension.datatype), true)
+    })
+  })
+
+  describe('.optional', () => {
+    it('should be false if no cube:Undefined datatype is defined', () => {
+      const dimension = buildCubeDimension({ path: ns.ex.property })
+
+      strictEqual(dimension.optional, false)
+    })
+
+    it('should be false if cube:Undefined is not part of the value list', () => {
+      const dimension = buildCubeDimension({ path: ns.ex.property, nodeKind: 'NamedNode' })
+
+      strictEqual(dimension.optional, false)
+    })
+
+    it('should be true if cube:Undefined datatype is defined', () => {
+      const dimension = buildCubeDimension({ path: ns.ex.property, datatype: ns.ex.datatype, optional: true })
+
+      strictEqual(dimension.optional, true)
+    })
+
+    it('should be true if cube:Undefined is part of the value list', () => {
+      const dimension = buildCubeDimension({ path: ns.ex.property, nodeKind: 'NamedNode', optional: true })
+
+      strictEqual(dimension.optional, true)
+    })
+  })
+})

--- a/test/support/buildCube.js
+++ b/test/support/buildCube.js
@@ -1,5 +1,6 @@
 const Cube = require('../../lib/Cube')
 const Source = require('../../lib/Source')
+const buildCubeDimension = require('./buildCubeDimension')
 const ns = require('./namespaces')
 
 function buildCube ({ dimensions = [] } = {}) {
@@ -17,8 +18,7 @@ function buildCube ({ dimensions = [] } = {}) {
 
       for (const dimension of dimensions) {
         shape.addOut(ns.sh.property, property => {
-          property
-            .addOut(ns.sh.path, dimension.term)
+          buildCubeDimension({ shape: property, ...dimension })
         })
       }
     })

--- a/test/support/buildCubeDimension.js
+++ b/test/support/buildCubeDimension.js
@@ -1,0 +1,46 @@
+const CubeDimension = require('../../lib/CubeDimension')
+const clownface = require('clownface')
+const rdf = require('rdf-ext')
+const ns = require('./namespaces')
+
+function buildCubeDimension ({ shape, path, datatype, nodeKind = 'Literal', optional = false, values = [] }) {
+  if (!shape) {
+    shape = clownface({ term: rdf.blankNode(), dataset: rdf.dataset() })
+  }
+
+  shape.addOut(ns.sh.path, path)
+
+  if (nodeKind) {
+    if (nodeKind === 'Literal') {
+      shape.addOut(ns.sh.nodeKind, ns.sh.Literal)
+    }
+
+    if (nodeKind === 'NamedNode') {
+      shape.addOut(ns.sh.nodeKind, ns.sh.IRI)
+    }
+  }
+
+  if (datatype) {
+    if (optional) {
+      if (nodeKind === 'Literal') {
+        shape
+          .addOut(ns.sh.or, union => union.addOut(ns.sh.datatype, ns.cube.Undefined))
+          .addOut(ns.sh.or, union => union.addOut(ns.sh.datatype, datatype))
+      }
+    } else {
+      shape.addOut(ns.sh.datatype, datatype)
+    }
+  }
+
+  if (values.length > 0 || (optional && nodeKind === 'NamedNode')) {
+    if ((optional && nodeKind === 'NamedNode')) {
+      values.push(ns.cube.Undefined)
+    }
+
+    shape.addList(ns.sh.in, values)
+  }
+
+  return new CubeDimension(shape)
+}
+
+module.exports = buildCubeDimension


### PR DESCRIPTION
This PR adds an `.optional` property to `CubeDimension`. It's a boolean value that is true if the datatype `cube:Undefined` is an allowed datatype or if `cube:Undefined` is in the `sh:in` list. `.datatype` returns always just one datatype. If `cube:Undefined` is one of the allowed datatypes, the other one is returned.