### PR TITLE
feat: support listing cubes without fetching shapes

### DIFF
--- a/lib/Cube.js
+++ b/lib/Cube.js
@@ -43,6 +43,14 @@ class Cube extends Node {
     return [prefix, query.toString()].join('')
   }
 
+  async fetchCube () {
+    const cubeData = await this.source.client.query.construct(this.cubeQuery())
+
+    this.dataset.addAll(cubeData)
+
+    this.quads = [...this.quads, ...cubeData]
+  }
+
   shapeQuery () {
     if (this.source.graph.termType === 'DefaultGraph') {
       return `${this.queryPrefix}DESCRIBE <${this.ptr.out(ns.cube.observationConstraint).value}>`
@@ -51,16 +59,17 @@ class Cube extends Node {
     return `${this.queryPrefix}DESCRIBE <${this.ptr.out(ns.cube.observationConstraint).value}> FROM <${this.source.graph.value}>`
   }
 
-  async init () {
-    // fetch cube + metadata
-    const cubeData = await this.source.client.query.construct(this.cubeQuery())
-    this.dataset.addAll(cubeData)
-
-    // fetch shapes
+  async fetchShape () {
     const shapeData = await this.source.client.query.construct(this.shapeQuery())
+
     this.dataset.addAll(shapeData)
 
-    this.quads = [...cubeData, ...shapeData]
+    this.quads = [...this.quads, ...shapeData]
+  }
+
+  async init () {
+    await this.fetchCube()
+    await this.fetchShape()
   }
 
   out (...args) {

--- a/lib/Source.js
+++ b/lib/Source.js
@@ -59,7 +59,7 @@ class Source extends Node {
     return cube
   }
 
-  async cubes ({ filters } = {}) {
+  async cubes ({ filters, noShape = false } = {}) {
     const rows = await this.client.query.select(cubesQuery({
       graph: this.graph,
       filters
@@ -72,7 +72,11 @@ class Source extends Node {
         source: this
       })
 
-      await cube.init()
+      await cube.fetchCube()
+
+      if (!noShape) {
+        await cube.fetchShape()
+      }
 
       return cube
     }))

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "sparql-http-client": "^2.2.2"
   },
   "devDependencies": {
+    "@rdfjs/express-handler": "^1.2.2",
     "express-as-promise": "^1.2.0",
     "mocha": "^8.2.1",
     "rdf-utils-fs": "^2.1.0",

--- a/test/Source.test.js
+++ b/test/Source.test.js
@@ -1,0 +1,123 @@
+const { strictEqual } = require('assert')
+const rdfHandler = require('@rdfjs/express-handler')
+const withServer = require('express-as-promise/withServer')
+const { describe, it } = require('mocha')
+const rdf = require('rdf-ext')
+const Cube = require('../lib/Cube')
+const Source = require('../lib/Source')
+const ns = require('./support/namespaces')
+
+describe('Source', () => {
+  it('should be a constructor', () => {
+    strictEqual(typeof Source, 'function')
+  })
+
+  describe('.cube', () => {
+    it('should be a method', () => {
+      const source = new Source({ endpointUrl: ns.ex.endpoint })
+
+      strictEqual(typeof source.cube, 'function')
+    })
+
+    it('should return an initialized cube', async () => {
+      await withServer(async server => {
+        let called = 0
+
+        server.app.get('/', rdfHandler(), (req, res) => {
+          called++
+
+          res.dataset(rdf.dataset([
+            rdf.quad(ns.ex.cube, ns.ex.predicate, ns.ex.object)
+          ]))
+        })
+
+        const source = new Source({ endpointUrl: await server.listen() })
+
+        const result = await source.cube(ns.ex.cube)
+
+        strictEqual(result instanceof Cube, true)
+        strictEqual(called, 2)
+      })
+    })
+  })
+
+  describe('.cubes', () => {
+    it('should be a method', () => {
+      const source = new Source({ endpointUrl: ns.ex.endpoint })
+
+      strictEqual(typeof source.cubes, 'function')
+    })
+
+    it('should return a list of initialized cubes', async () => {
+      await withServer(async server => {
+        let called = 0
+
+        server.app.get('/', rdfHandler(), (req, res) => {
+          called++
+
+          const query = req.query.query
+
+          if (query.includes('SELECT')) {
+            res.set('content-type', 'application/sparql-results+json').json({
+              results: {
+                bindings: [{
+                  cube: { type: 'uri', value: ns.ex.cube1.value }
+                }, {
+                  cube: { type: 'uri', value: ns.ex.cube2.value }
+                }]
+              }
+            })
+          } else {
+            res.dataset(rdf.dataset([
+              rdf.quad(ns.ex.cube, ns.ex.predicate, ns.ex.object)
+            ]))
+          }
+        })
+
+        const source = new Source({ endpointUrl: await server.listen() })
+
+        const result = await source.cubes()
+
+        strictEqual(Array.isArray(result), true)
+        strictEqual(result.length, 2)
+        strictEqual(result[0] instanceof Cube, true)
+        strictEqual(result[1] instanceof Cube, true)
+        strictEqual(called, 5)
+      })
+    })
+
+    it('should skip fetching the shape if noShape is true', async () => {
+      await withServer(async server => {
+        let called = 0
+
+        server.app.get('/', rdfHandler(), (req, res) => {
+          called++
+
+          const query = req.query.query
+
+          if (query.includes('SELECT')) {
+            res.set('content-type', 'application/sparql-results+json').json({
+              results: {
+                bindings: [{
+                  cube: { type: 'uri', value: ns.ex.cube1.value }
+                }, {
+                  cube: { type: 'uri', value: ns.ex.cube2.value }
+                }]
+              }
+            })
+          } else {
+            res.dataset(rdf.dataset([
+              rdf.quad(ns.ex.cube, ns.ex.predicate, ns.ex.object)
+            ]))
+          }
+        })
+
+        const source = new Source({ endpointUrl: await server.listen() })
+
+        await source.cubes({ noShape: true })
+
+        strictEqual(called, 3)
+      })
+    })
+  })
+})

--- a/test/support/buildCube.js
+++ b/test/support/buildCube.js
@@ -2,9 +2,9 @@ const Cube = require('../../lib/Cube')
 const Source = require('../../lib/Source')
 const ns = require('./namespaces')
 
-function buildCube ({ dimensions = [] } = {}) {
-  const source = new Source({ endpointUrl: ns.ex.endpoint })
-  const cube = new Cube({ parent: source })
+function buildCube ({ endpointUrl = ns.ex.endpoint, dimensions = [] } = {}) {
+  const source = new Source({ endpointUrl })
+  const cube = new Cube({ parent: source, source })
 
   cube.ptr
     .addOut(ns.rdf.type, ns.cube.Cube)


### PR DESCRIPTION
This PR adds an option to fetch the list of cubes without the shapes. A typical use case would look like this:

```js
// list all cubes without shapes
const cubes = await source.cubes({ noShape: true })

// select one of the cubes
const metaCube = cubes.find(c => Math.random() > 0.5)

// upgrade the cube to a full featured cube
const cube = await source.cube(metaCube.term)
```
