### PR TITLE
feat: optional query-prefix for each query operation.

### DIFF
--- a/examples/get-view-demo.js
+++ b/examples/get-view-demo.js
@@ -2,8 +2,12 @@ const { Source } = require('..')
 const rdf = require('rdf-ext')
 
 async function main () {
+  const queryPrefix = `#pragma describe.strategy cbd
+#pragma join.hash off
+`
   const source = new Source({
-    endpointUrl: 'https://int.lindas.admin.ch/query'
+    endpointUrl: 'https://int.lindas.admin.ch/query',
+    queryPrefix
   })
 
   const view = await source.view(rdf.namedNode('https://ld.stadt-zuerich.ch/statistics/view/V000002'))

--- a/examples/get-view-from-cube-demo.js
+++ b/examples/get-view-from-cube-demo.js
@@ -1,8 +1,12 @@
 const { Source, View } = require('..')
 
 async function main () {
+  const queryPrefix = `#pragma describe.strategy cbd
+#pragma join.hash off`
+
   const source = new Source({
-    endpointUrl: 'https://int.lindas.admin.ch/query'
+    endpointUrl: 'https://int.lindas.admin.ch/query',
+    queryPrefix
   })
 
   const cube = await source.cube('https://ld.stadt-zuerich.ch/statistics/ZUS-BTA-ZSA')

--- a/lib/Cube.js
+++ b/lib/Cube.js
@@ -17,7 +17,6 @@ class Cube extends Node {
 
     this.source = source
     this.ignore = new TermSet(ignore)
-    this.queryPrefix = '#pragma describe.strategy cbd\n'
     this.quads = []
   }
 
@@ -38,10 +37,8 @@ class Cube extends Node {
   }
 
   cubeQuery () {
-    const prefix = this.queryPrefix || ''
     const query = cubeQuery({ cube: this.term, graph: this.source.graph })
-
-    return [prefix, query.toString()].join('')
+    return query.toString()
   }
 
   async fetchCube () {
@@ -54,10 +51,10 @@ class Cube extends Node {
 
   shapeQuery () {
     if (!this.source.graph) {
-      return `${this.queryPrefix}DESCRIBE <${this.ptr.out(ns.cube.observationConstraint).value}>`
+      return `DESCRIBE <${this.ptr.out(ns.cube.observationConstraint).value}>`
     }
 
-    return `${this.queryPrefix}DESCRIBE <${this.ptr.out(ns.cube.observationConstraint).value}> FROM <${this.source.graph.value}>`
+    return `DESCRIBE <${this.ptr.out(ns.cube.observationConstraint).value}> FROM <${this.source.graph.value}>`
   }
 
   async fetchShape () {

--- a/lib/PrefixedSparqlClient.js
+++ b/lib/PrefixedSparqlClient.js
@@ -1,0 +1,10 @@
+function createPrefixedSparqlClient ({ client, queryPrefix }) {
+  const prefix = queryPrefix
+  return {
+    query: {
+      construct: (query, ...args) => client.query.construct(`${prefix}\n${query}`, ...args),
+      select: (query, ...args) => client.query.select(`${prefix}\n${query}`, ...args)
+    }
+  }
+}
+module.exports = createPrefixedSparqlClient

--- a/lib/Source.js
+++ b/lib/Source.js
@@ -6,9 +6,12 @@ const { toTerm } = require('./utils')
 const cubesQuery = require('./query/cubes.js')
 const viewListQuery = require('./query/views.js')
 const View = require('./View')
+const createPrefixedSparqlClient = require('./PrefixedSparqlClient.js')
+
+const DEFAULT_QUERY_PREFIX = '#pragma describe.strategy cbd'
 
 class Source extends Node {
-  constructor ({ parent, term, dataset, graph, endpointUrl, sourceGraph, user, password, queryOperation }) {
+  constructor ({ parent, term, dataset, graph, endpointUrl, sourceGraph, user, password, queryOperation, queryPrefix }) {
     super({
       parent,
       term,
@@ -25,14 +28,16 @@ class Source extends Node {
     this.user = user
     this.password = password
     this.queryOperation = queryOperation
+    this.queryPrefix = queryPrefix ?? DEFAULT_QUERY_PREFIX
   }
 
   get client () {
-    return new ParsingClient({
+    const client = new ParsingClient({
       endpointUrl: this.endpoint.value,
       user: this.user,
       password: this.password
     })
+    return createPrefixedSparqlClient({ client, queryPrefix: this.queryPrefix })
   }
 
   get endpoint () {

--- a/lib/Source.js
+++ b/lib/Source.js
@@ -28,7 +28,7 @@ class Source extends Node {
     this.user = user
     this.password = password
     this.queryOperation = queryOperation
-    this.queryPrefix = queryPrefix ?? DEFAULT_QUERY_PREFIX
+    this.queryPrefix = queryPrefix || DEFAULT_QUERY_PREFIX
   }
 
   get client () {

--- a/lib/View.js
+++ b/lib/View.js
@@ -4,10 +4,12 @@ const ns = require('./namespaces')
 const { findDataset, findParent, objectSetterGetter, toTerm } = require('./utils')
 const ViewQuery = require('./query/ViewQuery')
 const viewDefQuery = require('./query/view.js')
-const viewFullQuery = require('./query/viewFull.js')
 const Filter = require('./Filter.js')
 const rdf = require('rdf-ext')
 const TermSet = require('@rdfjs/term-set')
+
+const PRAGMA_DESCRIBE = '#pragma describe.strategy cbd\n'
+const PRAGMA_NO_JOIN_HASH = '#pragma join.hash off\n'
 
 class View extends Node {
   constructor ({ parent, term, dataset, graph, dimensions = [], filters = [], source } = {}) {
@@ -21,7 +23,6 @@ class View extends Node {
     this.source = source
     this.dimensions = []
     this.filters = []
-    this.queryPrefix = '#pragma describe.strategy cbd\n'
     this.quads = []
     this.shapesQuads = []
 
@@ -125,7 +126,7 @@ class View extends Node {
     return new ViewQuery(this.ptr, { disableDistinct })
   }
 
-  async observations ({ disableDistinct } = {}) {
+  async observations ({ disableDistinct, queryPrefix } = { disableDistinct: false, queryPrefix: PRAGMA_NO_JOIN_HASH }) {
     if (!this.dimensions.length) {
       throw Error('No dimensions')
     }
@@ -138,7 +139,7 @@ class View extends Node {
     const { query, dimensions } = this.observationsQuery({ disableDistinct })
 
     const columns = dimensions.array.filter(d => d.isResult).map(d => [d.variable, d.property])
-    const rows = await source.client.query.select(query, { operation: source.queryOperation })
+    const rows = await source.client.query.select(`${queryPrefix}${query}`, { operation: source.queryOperation })
 
     return rows.map(row => {
       const output = {}
@@ -151,12 +152,12 @@ class View extends Node {
     })
   }
 
-  async observationCount ({ disableDistinct } = {}) {
+  async observationCount ({ disableDistinct, queryPrefix } = { disableDistinct: false, queryPrefix: PRAGMA_NO_JOIN_HASH }) {
     const source = this.getMainSource()
 
     const { countQuery } = this.observationsQuery({ disableDistinct })
 
-    const result = await source.client.query.select(countQuery, { operation: source.queryOperation })
+    const result = await source.client.query.select(`${queryPrefix}${countQuery}`, { operation: source.queryOperation })
 
     if (!result.length) {
       return NaN
@@ -167,11 +168,11 @@ class View extends Node {
 
   static fromCube (cube) {
     if (!cube) {
-      throw Error('Needs a cube')
+      throw Error('requires cube')
     }
 
     if (!cube.source) {
-      throw Error('Needs source')
+      throw Error('requires source')
     }
 
     cube.source.ptr
@@ -222,8 +223,6 @@ class View extends Node {
           current.deleteOut(ns.view.dimension)
           current.deleteOut(ns.view.direction)
         }
-        // This hangs clownface!
-        // projectionPtr.deleteList(ns.view.orderBy)
         projectionPtr.deleteOut(ns.view.orderBy)
       }
     } else {
@@ -262,21 +261,21 @@ class View extends Node {
   cubeShapeQuery (cubeUri) {
     const source = this.getMainSource()
     if (!source.graph) {
-      return `${this.queryPrefix}DESCRIBE <${cubeUri}> ?s
+      return `DESCRIBE <${cubeUri}> ?s
 WHERE {
     <${cubeUri}> <https://cube.link/observationConstraint> ?s
 }
 `
     }
 
-    return `${this.queryPrefix}DESCRIBE ?s <${cubeUri}> FROM <${source.graph.value}>
+    return `DESCRIBE ?s <${cubeUri}> FROM <${source.graph.value}>
 WHERE {
     <${cubeUri}> <https://cube.link/observationConstraint> ?s
 }
 `
   }
 
-  async fetchCubesShapes () {
+  async fetchCubesShapes ({ queryPrefix } = { queryPrefix: PRAGMA_DESCRIBE }) {
     const cubes = this.cubes()
     if (!cubes || !cubes.length) {
       throw new Error('No cubes found')
@@ -284,7 +283,8 @@ WHERE {
     const source = this.getMainSource()
     this.shapesQuads = []
     for (const cube of cubes) {
-      const cubeShapeData = await source.client.query.construct(this.cubeShapeQuery(cube.value))
+      const query = this.cubeShapeQuery(cube.value)
+      const cubeShapeData = await source.client.query.construct(`${queryPrefix}${query}`)
 
       if (!cubeShapeData.length) {
         throw Error(`No shape data found at ${source.endpoint}, for cube ${cube.value}`)
@@ -298,16 +298,14 @@ WHERE {
 
   fetchViewQuery () {
     const source = this.getMainSource()
-    const prefix = this.queryPrefix || ''
     const query = viewDefQuery({ view: this.term, source: source.graph })
-
-    return [prefix, query.toString()].join('')
+    return query.toString()
   }
 
-  async fetchView () {
+  async fetchView ({ queryPrefix } = { queryPrefix: PRAGMA_DESCRIBE }) {
     const source = this.getMainSource()
     const query = this.fetchViewQuery(source)
-    const viewData = await source.client.query.construct(query)
+    const viewData = await source.client.query.construct(`${queryPrefix}${query}`)
     this.dataset.addAll(viewData)
     this.quads = [...this.quads, ...viewData]
   }
@@ -317,17 +315,18 @@ WHERE {
     this.updateEntities(this.source)
   }
 
-  fetchViewFullQuery () {
+  describeQuery (uri) {
     const source = this.getMainSource()
-    const prefix = this.queryPrefix || ''
-    const query = viewFullQuery({ view: this.term, graph: source.graph })
-    return [prefix, query.toString()].join('')
+    if (!source.graph) {
+      return `${this.queryPrefix}DESCRIBE <${uri}> ?s`
+    }
+    return `${this.queryPrefix}DESCRIBE ?s <${uri}> FROM <${source.graph.value}>`
   }
 
-  async fetchViewFull () {
+  async fetchViewFull ({ queryPrefix } = { queryPrefix: PRAGMA_DESCRIBE }) {
     const source = this.getMainSource()
-    const query = this.fetchViewFullQuery()
-    const data = await source.client.query.construct(query)
+    const query = this.describeQuery(this.term.value)
+    const data = await source.client.query.construct(`${queryPrefix}${query}`)
     this.clear()
     this.dataset.addAll(data)
   }

--- a/lib/View.js
+++ b/lib/View.js
@@ -8,9 +8,6 @@ const Filter = require('./Filter.js')
 const rdf = require('rdf-ext')
 const TermSet = require('@rdfjs/term-set')
 
-const PRAGMA_DESCRIBE = '#pragma describe.strategy cbd\n'
-const PRAGMA_NO_JOIN_HASH = '#pragma join.hash off\n'
-
 class View extends Node {
   constructor ({ parent, term, dataset, graph, dimensions = [], filters = [], source } = {}) {
     super({
@@ -126,7 +123,7 @@ class View extends Node {
     return new ViewQuery(this.ptr, { disableDistinct })
   }
 
-  async observations ({ disableDistinct, queryPrefix } = { disableDistinct: false, queryPrefix: PRAGMA_NO_JOIN_HASH }) {
+  async observations ({ disableDistinct } = { disableDistinct: false }) {
     if (!this.dimensions.length) {
       throw Error('No dimensions')
     }
@@ -139,7 +136,7 @@ class View extends Node {
     const { query, dimensions } = this.observationsQuery({ disableDistinct })
 
     const columns = dimensions.array.filter(d => d.isResult).map(d => [d.variable, d.property])
-    const rows = await source.client.query.select(`${queryPrefix}${query}`, { operation: source.queryOperation })
+    const rows = await source.client.query.select(query, { operation: source.queryOperation })
 
     return rows.map(row => {
       const output = {}
@@ -152,12 +149,12 @@ class View extends Node {
     })
   }
 
-  async observationCount ({ disableDistinct, queryPrefix } = { disableDistinct: false, queryPrefix: PRAGMA_NO_JOIN_HASH }) {
+  async observationCount ({ disableDistinct } = { disableDistinct: false }) {
     const source = this.getMainSource()
 
     const { countQuery } = this.observationsQuery({ disableDistinct })
 
-    const result = await source.client.query.select(`${queryPrefix}${countQuery}`, { operation: source.queryOperation })
+    const result = await source.client.query.select(countQuery, { operation: source.queryOperation })
 
     if (!result.length) {
       return NaN
@@ -275,7 +272,7 @@ WHERE {
 `
   }
 
-  async fetchCubesShapes ({ queryPrefix } = { queryPrefix: PRAGMA_DESCRIBE }) {
+  async fetchCubesShapes () {
     const cubes = this.cubes()
     if (!cubes || !cubes.length) {
       throw new Error('No cubes found')
@@ -284,7 +281,7 @@ WHERE {
     this.shapesQuads = []
     for (const cube of cubes) {
       const query = this.cubeShapeQuery(cube.value)
-      const cubeShapeData = await source.client.query.construct(`${queryPrefix}${query}`)
+      const cubeShapeData = await source.client.query.construct(query)
 
       if (!cubeShapeData.length) {
         throw Error(`No shape data found at ${source.endpoint}, for cube ${cube.value}`)
@@ -302,10 +299,10 @@ WHERE {
     return query.toString()
   }
 
-  async fetchView ({ queryPrefix } = { queryPrefix: PRAGMA_DESCRIBE }) {
+  async fetchView () {
     const source = this.getMainSource()
     const query = this.fetchViewQuery(source)
-    const viewData = await source.client.query.construct(`${queryPrefix}${query}`)
+    const viewData = await source.client.query.construct(query)
     this.dataset.addAll(viewData)
     this.quads = [...this.quads, ...viewData]
   }
@@ -318,15 +315,15 @@ WHERE {
   describeQuery (uri) {
     const source = this.getMainSource()
     if (!source.graph) {
-      return `${this.queryPrefix}DESCRIBE <${uri}> ?s`
+      return `DESCRIBE <${uri}> ?s`
     }
-    return `${this.queryPrefix}DESCRIBE ?s <${uri}> FROM <${source.graph.value}>`
+    return `DESCRIBE ?s <${uri}> FROM <${source.graph.value}>`
   }
 
-  async fetchViewFull ({ queryPrefix } = { queryPrefix: PRAGMA_DESCRIBE }) {
+  async fetchViewFull () {
     const source = this.getMainSource()
     const query = this.describeQuery(this.term.value)
-    const data = await source.client.query.construct(`${queryPrefix}${query}`)
+    const data = await source.client.query.construct(query)
     this.clear()
     this.dataset.addAll(data)
   }

--- a/lib/query/viewFull.js
+++ b/lib/query/viewFull.js
@@ -1,8 +1,0 @@
-const rdf = require('rdf-ext')
-
-function viewFullQuery ({ view, graph = rdf.defaultGraph() } = {}) {
-  return `#pragma describe.strategy cbd 
-DESCRIBE <${view.value}>`
-}
-
-module.exports = viewFullQuery

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "clownface": "^1.0.0",
     "commander": "^5.1.0",
     "rdf-ext": "^1.3.0",
-    "rdf-sparql-builder": "^0.1.8",
+    "rdf-sparql-builder": "^0.1.10",
     "sparql-http-client": "^2.2.2"
   },
   "devDependencies": {


### PR DESCRIPTION
https://github.com/zazuko/rdf-cube-view-query/issues/80

All query operations accept an optional queryPrefix, it defaults to DESCRIBE when retrieving documents and no join hash to Observations

