### PR TITLE
Backward compatibility

### DIFF
--- a/lib/Cube.js
+++ b/lib/Cube.js
@@ -50,7 +50,7 @@ class Cube extends Node {
   }
 
   shapeQuery () {
-    if (!this.source.graph) {
+    if (!this.source.graph || this.source.graph.termType === 'DefaultGraph') {
       return `DESCRIBE <${this.ptr.out(ns.cube.observationConstraint).value}>`
     }
 

--- a/lib/View.js
+++ b/lib/View.js
@@ -40,8 +40,10 @@ class View extends Node {
 
   dimension ({ cubeDimension }) {
     if (cubeDimension) {
+      const term = toTerm(cubeDimension)
+
       return this.dimensions.find(dimension => {
-        return dimension.cubeDimensions.some(current => current.path.equals(cubeDimension.path))
+        return dimension.cubeDimensions.some(current => current.path.equals(cubeDimension.path) || current.path.equals(term))
       })
     }
 


### PR DESCRIPTION
After the bump from 1.9.0 to 1.10.0, visualize.admin could not load
observations.

After dissecting the changes from 1.9.0 to 1.10.0, I've found two
small changes that would make the queries that we make in visualize.admin
work again.

I also had to add `sourceGraph: rdf.defaultGraph()` in the Source
constructor on our side (this default parameter was removed from 1.9.0
to 1.10.0).

- fix: If source graph is default graph, use simple query
- fix: Allow for dimension to be matched by term for backward compatibility
