### PR TITLE
feat: use path if view from is not there.

### DIFF
--- a/lib/query/ViewQuery/Dimensions.js
+++ b/lib/query/ViewQuery/Dimensions.js
@@ -11,7 +11,7 @@ class Dimensions {
     const filterDimensions = view.out(ns.view.filter).out(ns.view.dimension)
 
     this.array = distinct(resultDimensions, filterDimensions).toArray().map(dimension => {
-      const property = dimension.out(ns.view.as).term
+      const property = dimension.out(ns.view.as).term ?? dimension.out(ns.view.from).out(ns.view.path).term
       const isResult = contains(dimension.in(ns.view.dimension), view)
       const isAggregate = contains(dimension.out(ns.view.aggregate))
       const isFilter = contains(dimension.in(ns.view.dimension).in(ns.view.filter), view)

--- a/lib/query/ViewQuery/Dimensions.js
+++ b/lib/query/ViewQuery/Dimensions.js
@@ -2,13 +2,6 @@ const ns = require('../../namespaces')
 const { contains, distinct } = require('../utils')
 const rdf = require('rdf-ext')
 
-function resolveProperty (dimensionPtr) {
-  if (dimensionPtr.out(ns.view.as).term) {
-    return dimensionPtr.out(ns.view.as).term
-  }
-  const candidate = dimensionPtr.out(ns.view.from).out(ns.view.path).term
-  return candidate?.termType === 'NamedNode' ? candidate : rdf.blankNode()
-}
 class Dimensions {
   constructor (viewQuery) {
     this.viewQuery = viewQuery
@@ -42,6 +35,14 @@ class Dimensions {
   get (term) {
     return this.array.find(dimension => dimension.ptr.term.equals(term))
   }
+}
+
+function resolveProperty (dimensionPtr) {
+  if (dimensionPtr.out(ns.view.as).term) {
+    return dimensionPtr.out(ns.view.as).term
+  }
+  const candidate = dimensionPtr.out(ns.view.from).out(ns.view.path).term
+  return candidate?.termType === 'NamedNode' ? candidate : rdf.blankNode()
 }
 
 module.exports = Dimensions

--- a/lib/query/ViewQuery/Dimensions.js
+++ b/lib/query/ViewQuery/Dimensions.js
@@ -42,7 +42,7 @@ function resolveProperty (dimensionPtr) {
     return dimensionPtr.out(ns.view.as).term
   }
   const candidate = dimensionPtr.out(ns.view.from).out(ns.view.path).term
-  return candidate?.termType === 'NamedNode' ? candidate : rdf.blankNode()
+  return candidate && candidate.termType === 'NamedNode' ? candidate : rdf.blankNode()
 }
 
 module.exports = Dimensions

--- a/lib/query/ViewQuery/Dimensions.js
+++ b/lib/query/ViewQuery/Dimensions.js
@@ -1,6 +1,14 @@
 const ns = require('../../namespaces')
 const { contains, distinct } = require('../utils')
+const rdf = require('rdf-ext')
 
+function resolveProperty (dimensionPtr) {
+  if (dimensionPtr.out(ns.view.as).term) {
+    return dimensionPtr.out(ns.view.as).term
+  }
+  const candidate = dimensionPtr.out(ns.view.from).out(ns.view.path).term
+  return candidate && candidate.termType === 'NamedNode' ? candidate : rdf.blankNode()
+}
 class Dimensions {
   constructor (viewQuery) {
     this.viewQuery = viewQuery
@@ -11,7 +19,7 @@ class Dimensions {
     const filterDimensions = view.out(ns.view.filter).out(ns.view.dimension)
 
     this.array = distinct(resultDimensions, filterDimensions).toArray().map(dimension => {
-      const property = dimension.out(ns.view.as).term ? dimension.out(ns.view.as).term : dimension.out(ns.view.from).out(ns.view.path).term
+      const property = resolveProperty(dimension)
       const isResult = contains(dimension.in(ns.view.dimension), view)
       const isAggregate = contains(dimension.out(ns.view.aggregate))
       const isFilter = contains(dimension.in(ns.view.dimension).in(ns.view.filter), view)

--- a/lib/query/ViewQuery/Dimensions.js
+++ b/lib/query/ViewQuery/Dimensions.js
@@ -11,7 +11,7 @@ class Dimensions {
     const filterDimensions = view.out(ns.view.filter).out(ns.view.dimension)
 
     this.array = distinct(resultDimensions, filterDimensions).toArray().map(dimension => {
-      const property = dimension.out(ns.view.as).term ?? dimension.out(ns.view.from).out(ns.view.path).term
+      const property = dimension.out(ns.view.as).term ? dimension.out(ns.view.as).term : dimension.out(ns.view.from).out(ns.view.path).term
       const isResult = contains(dimension.in(ns.view.dimension), view)
       const isAggregate = contains(dimension.out(ns.view.aggregate))
       const isFilter = contains(dimension.in(ns.view.dimension).in(ns.view.filter), view)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rdf-cube-view-query",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "RDF Cube View Schema query library",
   "main": "index.js",
   "scripts": {

--- a/test/ViewQuery/Dimensions.test.js
+++ b/test/ViewQuery/Dimensions.test.js
@@ -1,0 +1,99 @@
+const { strictEqual } = require('assert')
+const { describe, it } = require('mocha')
+const rdf = require('rdf-ext')
+const clownface = require('clownface')
+
+const ns = require('../support/namespaces')
+const Dimensions = require('../../lib/query/ViewQuery/Dimensions.js')
+const { Parser } = require('n3')
+
+describe('Dimensions', () => {
+  it('gets the property from view:as', () => {
+    const viewTTL = `
+@prefix view: <https://cube.link/view/> .
+@prefix ex: <http://example.org/> .
+ex:view a view:View ;
+  view:dimension [
+        view:from [
+            view:path ex:someOther ;
+        ] ;
+        view:as ex:some ;
+    ] .
+`
+    const parser = new Parser()
+    const dataset = rdf.dataset().addAll(parser.parse(viewTTL))
+    const view = clownface({ dataset, term: ns.ex.view })
+
+    const dimensions = new Dimensions({ view, variable: () => {} })
+
+    strictEqual(ns.ex.some.value, dimensions.array[0].property.value)
+  })
+
+  it('gets the property from path when view:as is not defined and path is an IRI',
+    () => {
+      const viewTTL = `
+@prefix view: <https://cube.link/view/> .
+@prefix ex: <http://example.org/> .
+ex:view a view:View ;
+  view:dimension [
+        view:from [
+            view:path ex:someOther ;
+        ] ;
+    ] .
+`
+      const parser = new Parser()
+      const dataset = rdf.dataset().addAll(parser.parse(viewTTL))
+      const view = clownface({ dataset, term: ns.ex.view })
+
+      const dimensions = new Dimensions({ view, variable: () => {} })
+
+      strictEqual(ns.ex.someOther.value, dimensions.array[0].property.value)
+    })
+
+  it(
+    'gets a blank as property when view:as is not defined and path is a list',
+    () => {
+      const viewTTL = `
+@prefix view: <https://cube.link/view/> .
+@prefix ex: <http://example.org/> .
+ex:view a view:View ;
+  view:dimension [
+        view:from [
+            view:path (
+              ex:some 
+              ex:someOther
+            ) ;
+        ] ;
+    ] .
+`
+      const parser = new Parser()
+      const dataset = rdf.dataset().addAll(parser.parse(viewTTL))
+      const view = clownface({ dataset, term: ns.ex.view })
+
+      const dimensions = new Dimensions({ view, variable: () => {} })
+
+      strictEqual('BlankNode', dimensions.array[0].property.termType)
+    })
+
+  it(
+    'gets a blank as property when view:as is not defined and path is a blank',
+    () => {
+      const viewTTL = `
+@prefix view: <https://cube.link/view/> .
+@prefix ex: <http://example.org/> .
+ex:view a view:View ;
+  view:dimension [
+        view:from [
+            view:path [ ex:notMe ex:please ] ;
+        ] ;
+    ] .
+`
+      const parser = new Parser()
+      const dataset = rdf.dataset().addAll(parser.parse(viewTTL))
+      const view = clownface({ dataset, term: ns.ex.view })
+
+      const dimensions = new Dimensions({ view, variable: () => {} })
+
+      strictEqual('BlankNode', dimensions.array[0].property.termType)
+    })
+})


### PR DESCRIPTION

Currently, the lib cannot retrieve observations if dimensions are defined without the view:as predicate/value.

```turtle
_:b247 a <https://cube.link/view/Dimension> ;
 rdfs:label "Measure Wirtschaftliche Wohnbevölkerung (Bevölkerung nach Stadtquartier, Stadtkreis, Stadt, Zivistand, 10-Jahres-Altersklassen und Geschlecht)" ;
 <https://cube.link/view/from> [
  <https://cube.link/view/path> <https://ld.stadt-zuerich.ch/statistics/measure/BEW> ;
  <https://cube.link/view/source> _:b2 ;
 ] ;
 <https://cube.link/view/as> <https://ld.stadt-zuerich.ch/statistics/property/BEW> .
 ```
This change honors view:as if it's there or uses from/path as a fallback, so the following can work also:

```turtle
_:b247 a <https://cube.link/view/Dimension> ;
 rdfs:label "Measure Wirtschaftliche Wohnbevölkerung (Bevölkerung nach Stadtquartier, Stadtkreis, Stadt, Zivistand, 10-Jahres-Altersklassen und Geschlecht)" ;
 <https://cube.link/view/from> [
  <https://cube.link/view/path> <https://ld.stadt-zuerich.ch/statistics/measure/BEW> ;
  <https://cube.link/view/source> _:b2 ;
 ] .
 ```


Fixes: https://github.com/StatistikStadtZuerich/APD/issues/175