### PR TITLE
chore: throw verbose Error

### DIFF
--- a/lib/View.js
+++ b/lib/View.js
@@ -180,6 +180,9 @@ class View extends Node {
 
     const view = new View({ parent: cube, source: cube.source })
     cube.dimensions.forEach(cubeDimension => {
+      if (!cubeDimension.path) {
+        throw new Error(`Cube dimension <${cubeDimension.ptr.term.value}> requires a path`)
+      }
       const viewDimension = view.createDimension({
         source: cube.source, path: cubeDimension.path, as: cubeDimension.path
       })

--- a/test/View.test.js
+++ b/test/View.test.js
@@ -644,5 +644,22 @@ ex:view view:projection [
       strictEqual(dimensions[0].cubeDimensions[0].path.value, ns.ex.property1.value)
       strictEqual(dimensions[1].cubeDimensions[0].path.value, ns.ex.property2.value)
     })
+
+    it('View.fromCube should fail with an explanation if required path is missing', () => {
+      const cube = buildCube({
+        dimensions: [{
+          path: ns.ex.propertyA
+        }, {
+          path: undefined
+        }]
+      })
+
+      throws(() => {
+        View.fromCube(cube)
+      }, {
+        name: 'Error',
+        message: /Cube dimension <[^>]+> requires a path/
+      })
+    })
   })
 })

--- a/test/support/buildCubeDimension.js
+++ b/test/support/buildCubeDimension.js
@@ -8,7 +8,9 @@ function buildCubeDimension ({ shape, path, datatype, nodeKind = 'Literal', opti
     shape = clownface({ term: rdf.blankNode(), dataset: rdf.dataset() })
   }
 
-  shape.addOut(ns.sh.path, path)
+  if (path) {
+    shape.addOut(ns.sh.path, path)
+  }
 
   if (nodeKind) {
     if (nodeKind === 'Literal') {


### PR DESCRIPTION
When generating Views from a cube using View.fromCube(cube), and any cube dimension does not have a path defined, the lib currently errors without feedback.

This provides feedback to the developer explaining the path is needed