### PR TITLE
feat: Improve sorting performance when creating View from Cube

### DIFF
--- a/.changeset/many-panthers-scream.md
+++ b/.changeset/many-panthers-scream.md
@@ -1,0 +1,5 @@
+---
+"rdf-cube-view-query": minor
+---
+
+feat: add the option to disable sorting view columns (dimensions) (re #95)

--- a/.changeset/tricky-grapes-own.md
+++ b/.changeset/tricky-grapes-own.md
@@ -1,0 +1,5 @@
+---
+"rdf-cube-view-query": patch
+---
+
+fix: `View.fromCube` was slow when sorting dimensions (fixes #95)

--- a/lib/View.js
+++ b/lib/View.js
@@ -165,7 +165,7 @@ class View extends Node {
     return parseInt(result[0].count.value)
   }
 
-  static fromCube (cube) {
+  static fromCube (cube, sortColumns = true) {
     if (!cube) {
       throw Error('requires cube')
     }
@@ -189,18 +189,21 @@ class View extends Node {
       view.addDimension(viewDimension)
     })
 
-    view.setDefaultColumns()
+    view.setDefaultColumns(sortColumns)
 
     return view
   }
 
-  setDefaultColumns () {
-    const collator = new Intl.Collator("en", { numeric: true })
+  setDefaultColumns (sort) {
     const orderingColumns = this.dimensions.map((dimension) => ({
       iri: dimension.cubeDimensions[0].path.value,
       term: dimension.ptr.term
     }))
-    orderingColumns.sort((a, b) => collator.compare(a.iri, b.iri))
+
+    if (sort) {
+      const collator = new Intl.Collator("en", { numeric: true })
+      orderingColumns.sort((a, b) => collator.compare(a.iri, b.iri))
+    }
 
     const projectionPtr = this.ptr.out(ns.view.projection)
     projectionPtr.addList(ns.view.columns,

--- a/lib/View.js
+++ b/lib/View.js
@@ -195,14 +195,16 @@ class View extends Node {
   }
 
   setDefaultColumns () {
-    const orderingColumns = [...this.dimensions]
-    const sortAlphaNum = (a, b) => a.cubeDimensions[0].path.value.localeCompare(
-      b.cubeDimensions[0].path.value, 'en', { numeric: true })
-    orderingColumns.sort(sortAlphaNum)
+    const collator = new Intl.Collator("en", { numeric: true })
+    const orderingColumns = this.dimensions.map((dimension) => ({
+      iri: dimension.cubeDimensions[0].path.value,
+      term: dimension.ptr.term
+    }))
+    orderingColumns.sort((a, b) => collator.compare(a.iri, b.iri))
 
     const projectionPtr = this.ptr.out(ns.view.projection)
     projectionPtr.addList(ns.view.columns,
-      orderingColumns.map(dimension => dimension.ptr.term))
+      orderingColumns.map(dimension => dimension.term))
   }
 
   orderBy (orderBy) {


### PR DESCRIPTION
Closes #95.

This PR improves sorting performance in `sortDefaultColumns` in `View.fromCube`. Previously it took more than 0.5s to sort 72 dimensions, mostly due to accessing a nested object each time in the sort function. By changing the logic to first create a flat structure (and additionally extracting the collator to not create it each time a sort function is called), the performance improved ~10x (0.5s -> 0.05s).

Since sorting is not always needed (in Visualize.admin we sort the dimensions and observations using custom logic), I also added an option to disable sorting of columns altogether.